### PR TITLE
Fix initialization ValueError if git command failed

### DIFF
--- a/cluster_pack/_version.py
+++ b/cluster_pack/_version.py
@@ -295,7 +295,10 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         pieces["closest-tag"] = None
         count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
                                     cwd=root)
-        pieces["distance"] = int(count_out)  # total number of commits
+        try:
+            pieces["distance"] = int(count_out)  # total number of commits
+        except ValueError:
+            pieces["distance"] = 0
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
     date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],


### PR DESCRIPTION
Hello, this is to fix
`ValueError: invalid literal for int() with base 10: ''`
at import time when having cluster-pack as a dependency and in case the git command failed (in my case it did because of gunicorn).