### PR TITLE
Remove __version__

### DIFF
--- a/cluster_pack/__init__.py
+++ b/cluster_pack/__init__.py
@@ -1,9 +1,3 @@
-
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions
-
-
 from cluster_pack.uploader import (
     upload_env,
     upload_zip,


### PR DESCRIPTION
Seems unsafe, see
https://github.com/criteo/cluster-pack/pull/67

Investigate why it calls git at runtime in this case.