### PR TITLE
Disable hdfs tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,37 +49,37 @@ jobs:
     - name: Run spark Job
       run: docker exec spark-master ./examples/spark-with-S3/scripts/run_spark_example.sh
 
-  hadoop_hdfs:
-    runs-on: ubuntu-latest
+  # hadoop_hdfs:
+  #   runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v2
+  #   steps:
+  #   - uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.6
+  #   - name: Set up Python 3.6
+  #     uses: actions/setup-python@v2
+  #     with:
+  #       python-version: 3.6
 
-    - name: Install hadoop-test-cluster
-      run: |
-        pip install hadoop-test-cluster
+  #   - name: Install hadoop-test-cluster
+  #     run: |
+  #       pip install hadoop-test-cluster
 
-    - name: Start cluster
-      run: |
-        htcluster startup --image cdh5 --mount .:cluster-pack
+  #   - name: Start cluster
+  #     run: |
+  #       htcluster startup --image cdh5 --mount .:cluster-pack
 
-    - name: Start Job
-      run: |
-        # for the hack with script .. see https://github.com/actions/runner/issues/241#issuecomment-577360161
-        # the prebuild image only contains a conda install, we also install python 3.6.10
-        # to avoid sharing files on the worker node we copy the python3.6 install script via hdfs to worker /tmp folder
-        script -e -c "htcluster exec -u root -s edge -- chown -R testuser /home/testuser && \
-                      htcluster exec -u root -s edge -- /home/testuser/cluster-pack/tests/integration/install_python.sh && \                    
-                      htcluster exec -u root -s edge -- hdfs dfs -put /home/testuser/cluster-pack/tests/integration/install_python.sh hdfs:///tmp && \
-                      htcluster exec -u root -s worker -- hdfs dfs -get hdfs:///tmp/install_python.sh /home/testuser && \
-                      htcluster exec -u root -s worker -- chmod +x /home/testuser/install_python.sh && \
-                      htcluster exec -u root -s worker -- /home/testuser/install_python.sh && \
-                      htcluster exec -s edge -- /home/testuser/cluster-pack/tests/integration/hadoop_hdfs_tests.sh"
+  #   - name: Start Job
+  #     run: |
+  #       # for the hack with script .. see https://github.com/actions/runner/issues/241#issuecomment-577360161
+  #       # the prebuild image only contains a conda install, we also install python 3.6.10
+  #       # to avoid sharing files on the worker node we copy the python3.6 install script via hdfs to worker /tmp folder
+  #       script -e -c "htcluster exec -u root -s edge -- chown -R testuser /home/testuser && \
+  #                     htcluster exec -u root -s edge -- /home/testuser/cluster-pack/tests/integration/install_python.sh && \                    
+  #                     htcluster exec -u root -s edge -- hdfs dfs -put /home/testuser/cluster-pack/tests/integration/install_python.sh hdfs:///tmp && \
+  #                     htcluster exec -u root -s worker -- hdfs dfs -get hdfs:///tmp/install_python.sh /home/testuser && \
+  #                     htcluster exec -u root -s worker -- chmod +x /home/testuser/install_python.sh && \
+  #                     htcluster exec -u root -s worker -- /home/testuser/install_python.sh && \
+  #                     htcluster exec -s edge -- /home/testuser/cluster-pack/tests/integration/hadoop_hdfs_tests.sh"
 
   conda:
     runs-on: ubuntu-latest


### PR DESCRIPTION
hadoop-test-cluster (https://github.com/jcrist/hadoop-test-cluster) started failing beacuse it used some cloudera images that are now behind a paywall
see https://www.cloudera.com/downloads/paywall-expansion.html

"failure: repodata/repomd.xml from cloudera-cdh5: [Errno 256] No more mirrors to try.
https://archive.cloudera.com/cdh5/redhat/7/x86_64/cdh/5/repodata/repomd.xml: [Errno 14]  Error 401 - The requested URL returned error: 401 Authentication required"