### PR TITLE
Fix package suffix check for conda env

### DIFF
--- a/cluster_pack/packaging.py
+++ b/cluster_pack/packaging.py
@@ -298,7 +298,7 @@ def detect_archive_names(
         package_path = (f"{get_default_fs()}/user/{getpass.getuser()}"
                         f"/envs/{env_name}.{packer.extension()}")
     else:
-        if pathlib.Path(package_path).suffix != f".{packer.extension()}":
+        if "".join(pathlib.Path(package_path).suffixes) != f".{packer.extension()}":
             raise ValueError(f"{package_path} has the wrong extension"
                              f", .{packer.extension()} is expected")
 


### PR DESCRIPTION
Fix this problem when upload/zip conda env to a given path

```python
>>> path, _ = cluster_pack.upload_env(package_path="/mnt/test1.tar.gz")

---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-c60e4a3efba1> in <module>
----> 1 path, _ = cluster_pack.upload_env(package_path="/mnt/test1.tar.gz")

/mnt/conda_envs/tf2/lib/python3.7/site-packages/cluster_pack/uploader.py in upload_env(package_path, packer, additional_packages, ignored_packages, force_upload, include_editable, fs_args)
    102     if packer is None:
    103         packer = packaging.detect_packer_from_env()
--> 104     package_path, env_name, pex_file = packaging.detect_archive_names(packer, package_path)
    105 
    106     resolved_fs, path = filesystem.resolve_filesystem_and_path(package_path, **fs_args)

/mnt/conda_envs/tf2/lib/python3.7/site-packages/cluster_pack/packaging.py in detect_archive_names(packer, package_path)
    300     else:
    301         if pathlib.Path(package_path).suffix != f".{packer.extension()}":
--> 302             raise ValueError(f"{package_path} has the wrong extension"
    303                              f", .{packer.extension()} is expected")
    304 

ValueError: /mnt/test1.tar.gz has the wrong extension, .tar.gz is expected
```