### PR TITLE
Unipined version of Pex

### DIFF
--- a/cluster_pack/packaging.py
+++ b/cluster_pack/packaging.py
@@ -28,6 +28,7 @@ except ImportError:
 
 from pex.pex_info import PexInfo
 from pex.interpreter import PythonInterpreter
+from pex.inherit_path import InheritPath
 
 from cluster_pack import filesystem, conda
 
@@ -134,7 +135,7 @@ def pack_in_pex(requirements: List[str],
 
     interpreter = PythonInterpreter.get()
     pex_info = PexInfo.default(interpreter)
-    pex_info.inherit_path = pex_inherit_path
+    pex_info.inherit_path = InheritPath.for_value(pex_inherit_path)
     pex_builder = PEXBuilder(
         copy=True,
         interpreter=interpreter,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cloudpickle
-pex<=2.1.18
+pex
 conda-pack
 pip>=18.1
 pyarrow


### PR DESCRIPTION
Torch could not be packaged with the previously pinned version due
to a bug fixed in 2.1.21
(same bug as described here https://github.com/pantsbuild/pex/issues/1017)