### PR TITLE
[fix] Pex uploader handles names containing dots

### DIFF
--- a/cluster_pack/packaging.py
+++ b/cluster_pack/packaging.py
@@ -296,7 +296,7 @@ def detect_archive_names(
 ) -> Tuple[str, str, str]:
     if _running_from_pex():
         pex_file = get_current_pex_filepath()
-        env_name = os.path.basename(pex_file).split('.')[0]
+        env_name = os.path.splitext(os.path.basename(pex_file))[0]
     else:
         pex_file = ""
         env_name = packer.env_name()
@@ -305,7 +305,7 @@ def detect_archive_names(
         package_path = (f"{get_default_fs()}/user/{getpass.getuser()}"
                         f"/envs/{env_name}.{packer.extension()}")
     else:
-        if "".join(pathlib.Path(package_path).suffixes) != f".{packer.extension()}":
+        if "".join(os.path.splitext(package_path)[1]) != f".{packer.extension()}":
             raise ValueError(f"{package_path} has the wrong extension"
                              f", .{packer.extension()} is expected")
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -188,7 +188,8 @@ def test_upload_env_in_a_pex():
         mock__get_archive_metadata_path = stack.enter_context(
             mock.patch(f"{MODULE_TO_TEST}._get_archive_metadata_path")
         )
-        mock__get_archive_metadata_path.return_value = f"{home_fs_path}/blah.json"
+        mock__get_archive_metadata_path.return_value = \
+            f"{home_fs_path}/blah-1.388585.133.497-review.json"
 
         # metadata & pex already exists on fs
         mock_fs.exists.return_value = True
@@ -205,14 +206,14 @@ def test_upload_env_in_a_pex():
 
         mock_pex_info.from_pex.side_effect = _from_pex
 
-        result = cluster_pack.upload_env(f'{home_fs_path}/blah.pex')
+        result = cluster_pack.upload_env(f'{home_fs_path}/blah-1.388585.133.497-review.pex')
 
         # Check copy pex to remote
         mock_fs.put.assert_any_call(
             f'{home_path}/myapp.pex',
-            f'{home_fs_path}/blah.pex')
+            f'{home_fs_path}/blah-1.388585.133.497-review.pex')
         # Check metadata has been cleaned
-        mock_fs.rm.assert_called_once_with(f'{home_fs_path}/blah.json')
+        mock_fs.rm.assert_called_once_with(f'{home_fs_path}/blah-1.388585.133.497-review.json')
         # check envname
         assert 'myapp' == result[1]
 


### PR DESCRIPTION
If the pex name had a dot such as: my-pex.1.34.56.pex, then the following name was uplaoded to HDFS: my-pex.1.pex instead of the full name.