### PR TITLE
Detect PEX filepath and if running in PEX with env var PEX

### DIFF
--- a/cluster_pack/conda.py
+++ b/cluster_pack/conda.py
@@ -2,14 +2,13 @@ import hashlib
 import json
 import logging
 import os
-import subprocess
 try:
     import conda_pack
 except NotImplementedError:
     # conda is not supported on windows
     pass
 
-from typing import Dict, List, Collection
+from typing import List
 
 from cluster_pack import process
 

--- a/cluster_pack/filesystem.py
+++ b/cluster_pack/filesystem.py
@@ -5,8 +5,8 @@ import shutil
 import types
 
 
-from typing import Dict, Tuple, Any, List, Iterator
-from pyarrow import filesystem, util
+from typing import Tuple, Any, List, Iterator
+from pyarrow import filesystem
 from urllib.parse import urlparse
 
 try:

--- a/cluster_pack/packaging.py
+++ b/cluster_pack/packaging.py
@@ -148,14 +148,7 @@ def _get_packages(editable: bool, executable: str = sys.executable) -> List[Json
 
     _logger.debug(f"'pip list' with editable={editable} results:" + results)
 
-    parsed_results = json.loads(results)
-
-    # https://pip.pypa.io/en/stable/reference/pip_freeze/?highlight=freeze#cmdoption--all
-    # freeze hardcodes to ignore those packages: wheel, distribute, pip, setuptools
-    # To be iso with freeze we also remove those packages
-    return [element for element in parsed_results
-            if element["name"] not in
-            ["distribute", "wheel", "pip", "setuptools"]]
+    return json.loads(results)
 
 
 class Packer(object):
@@ -315,8 +308,9 @@ def get_current_pex_filepath() -> str:
     """
     If we run from a pex, returns the path
     """
-    import _pex
-    return os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(_pex.__file__))))
+    if "PEX" not in os.environ:
+        raise RuntimeError("Trying to get current pex file path while not running from PEX")
+    return os.environ["PEX"]
 
 
 def get_editable_requirements(
@@ -356,11 +350,7 @@ def _is_conda_env() -> bool:
 
 
 def _running_from_pex() -> bool:
-    try:
-        import _pex
-        return True
-    except ModuleNotFoundError:
-        return False
+    return "PEX" in os.environ
 
 
 def _is_criteo() -> bool:

--- a/cluster_pack/skein/skein_config_builder.py
+++ b/cluster_pack/skein/skein_config_builder.py
@@ -1,12 +1,10 @@
 import cloudpickle
 import os
-import skein
-import time
 import uuid
 
 from typing import NamedTuple, Callable, Dict, List, Optional, Any
 
-from cluster_pack import packaging, uploader, filesystem
+from cluster_pack import packaging, uploader
 
 
 class SkeinConfig(NamedTuple):

--- a/cluster_pack/spark/spark_config_builder.py
+++ b/cluster_pack/spark/spark_config_builder.py
@@ -1,10 +1,9 @@
 
 import os
 import logging
-import pyspark
 from pyspark.sql import SparkSession
 
-from cluster_pack import packaging, uploader
+from cluster_pack import packaging
 
 from typing import Dict, Optional, Any
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cloudpickle
-pex==2.1.50
+pex==2.1.54
 conda-pack
 pip>=18.1
 pyarrow


### PR DESCRIPTION
It was not possible to detect whether or not we were running from within a pex for a long time (I don't know exactly what release of PEX removed this capability). It is now possible thanks to https://github.com/pantsbuild/pex/pull/1495