### PR TITLE
Correct error raising when packaging pex

### DIFF
--- a/cluster_pack/packaging.py
+++ b/cluster_pack/packaging.py
@@ -132,9 +132,11 @@ def pack_in_pex(requirements: List[str],
 
         try:
             print(f"Running command: {' '.join(cmd)}")
-            subprocess.run(cmd, check=True)
-        except CalledProcessError:
+            call = subprocess.run(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            call.check_returncode()
+        except CalledProcessError as err:
             _logger.exception('Cannot create pex')
+            _logger.exception(err.stderr.decode("ascii"))
             raise
 
     return output


### PR DESCRIPTION
This commit enables to have the pex packaging error directly in the notebook, removing the need to run the pex command if something goes awry.
It looks like there is a bug in subprocess.run when checking is activated, as the stderr is then the error in Python itself (on Linux at least).
Going in two steps solves the problem.