### PR TITLE
Fix race condition

### DIFF
--- a/cluster_pack/filesystem.py
+++ b/cluster_pack/filesystem.py
@@ -233,15 +233,15 @@ class EnhancedFileSystem(filesystem.FileSystem):
     def put_atomic(self,
          source_path: str,
          destination_path: str) -> None:
-        upload_dir = f"{destination_path}.{uuid.uuid4()}.tmp"
+        tmp_upload_dir = f"{destination_path}.{uuid.uuid4()}.tmp"
+        self.put(source_path, tmp_upload_dir)
         try:
-            self.put(source_path, upload_dir)
-            self.mv(upload_dir, destination_path)
+            self.mv(tmp_upload_dir, destination_path)
         except OSError as err:
             raise FileExistsError(f"File exist at destination {destination_path}", err)
         finally:
-            if self.exists(upload_dir):
-                self.rm(upload_dir, True)
+            if self.exists(tmp_upload_dir):
+                self.rm(tmp_upload_dir, True)
 
     def get(self, filename: str, path: str, chunk: int = 2**16) -> None:
         with open(path, 'wb') as target:

--- a/cluster_pack/filesystem.py
+++ b/cluster_pack/filesystem.py
@@ -74,6 +74,12 @@ def _rename(self: Any, path: str, new_path: str) -> None:
     os.rename(path, new_path)
 
 
+def _s3_rename(self: Any, path: str, new_path: str) -> None:
+    if self.exists(new_path):
+        raise OSError(f"File exist at destination {new_path}")
+    self.fs.mv(path, new_path)
+
+
 def _hdfs_st_mode(self: Any, path: str) -> int:
     st_mode = self.ls(path, True)[0]["permissions"]
     return int(st_mode)
@@ -206,6 +212,9 @@ class EnhancedFileSystem(filesystem.FileSystem):
             base_fs.chmod = types.MethodType(_chmod, base_fs)
             base_fs.rm = types.MethodType(_rm, base_fs)
             base_fs.rename = types.MethodType(_rename, base_fs)
+
+        if isinstance(base_fs, pyarrow.filesystem.S3FSWrapper):
+            base_fs.rename = types.MethodType(_s3_rename, base_fs)
 
         if isinstance(base_fs, pyarrow.hdfs.HadoopFileSystem):
             base_fs.st_mode = types.MethodType(_hdfs_st_mode, base_fs)

--- a/cluster_pack/filesystem.py
+++ b/cluster_pack/filesystem.py
@@ -1,5 +1,8 @@
+from genericpath import isdir
 import logging
+from operator import ne
 import os
+import uuid
 import pyarrow
 import shutil
 import types
@@ -63,6 +66,17 @@ def _rm(self: Any, path: str, recursive: bool = False) -> None:
             shutil.rmtree(path)
         else:
             os.rmdir(path)
+
+
+def _rename(self: Any, path: str, new_path: str) -> None:
+    if os.path.exists(new_path):
+        raise FileExistsError(f"File exist at destination {new_path}")
+    os.rename(path, new_path)
+
+
+def _hdfs_st_mode(self: Any, path: str) -> int:
+    st_mode = self.ls(path, True)[0]["permissions"]
+    return int(st_mode)
 
 
 def _preserve_acls(base_fs: Any, local_file: str, remote_file: str) -> None:
@@ -191,6 +205,10 @@ class EnhancedFileSystem(filesystem.FileSystem):
         if isinstance(base_fs, pyarrow.filesystem.LocalFileSystem):
             base_fs.chmod = types.MethodType(_chmod, base_fs)
             base_fs.rm = types.MethodType(_rm, base_fs)
+            base_fs.rename = types.MethodType(_rename, base_fs)
+
+        if isinstance(base_fs, pyarrow.hdfs.HadoopFileSystem):
+            base_fs.st_mode = types.MethodType(_hdfs_st_mode, base_fs)
         _expose_methods(self, base_fs, ignored=["open"])
 
     def put(self, filename: str, path: str, chunk: int = 2**16) -> None:
@@ -202,6 +220,21 @@ class EnhancedFileSystem(filesystem.FileSystem):
                         break
                     target.write(out)
         _preserve_acls(self.base_fs, filename, path)
+
+    def put_atomic(self,
+         source_path: str,
+         destination_path: str) -> None:
+        upload_dir = f"{destination_path}.{uuid.uuid4()}.tmp"
+        try:
+            if isdir(source_path) and not self.exists(upload_dir):
+                self.mkdir(upload_dir)
+            self.put(source_path, upload_dir)
+            self.mv(upload_dir, destination_path)
+        except OSError as err:
+            raise FileExistsError(f"File exist at destination {destination_path}", err)
+        finally:
+            if self.exists(upload_dir):
+                self.rm(upload_dir, True)
 
     def get(self, filename: str, path: str, chunk: int = 2**16) -> None:
         with open(path, 'wb') as target:

--- a/cluster_pack/filesystem.py
+++ b/cluster_pack/filesystem.py
@@ -70,7 +70,7 @@ def _rm(self: Any, path: str, recursive: bool = False) -> None:
 
 def _rename(self: Any, path: str, new_path: str) -> None:
     if os.path.exists(new_path):
-        raise FileExistsError(f"File exist at destination {new_path}")
+        raise OSError(f"File exist at destination {new_path}")
     os.rename(path, new_path)
 
 
@@ -226,8 +226,6 @@ class EnhancedFileSystem(filesystem.FileSystem):
          destination_path: str) -> None:
         upload_dir = f"{destination_path}.{uuid.uuid4()}.tmp"
         try:
-            if isdir(source_path) and not self.exists(upload_dir):
-                self.mkdir(upload_dir)
             self.put(source_path, upload_dir)
             self.mv(upload_dir, destination_path)
         except OSError as err:

--- a/cluster_pack/uploader.py
+++ b/cluster_pack/uploader.py
@@ -7,6 +7,7 @@ import sys
 import pathlib
 import tempfile
 from typing import (
+    Callable,
     Tuple,
     Dict,
     Collection,
@@ -31,7 +32,7 @@ def _get_archive_metadata_path(package_path: str) -> str:
 
 def _is_archive_up_to_date(package_path: str,
                            current_packages_list: List[str],
-                           resolved_fs: Any = None
+                           resolved_fs: filesystem.EnhancedFileSystem
                            ) -> bool:
     if not resolved_fs.exists(package_path):
         return False
@@ -46,7 +47,7 @@ def _is_archive_up_to_date(package_path: str,
 
 def _dump_archive_metadata(package_path: str,
                            current_packages_list: List[str],
-                           resolved_fs: Any = None
+                           resolved_fs: filesystem.EnhancedFileSystem
                            ) -> None:
     archive_meta_data = _get_archive_metadata_path(package_path)
     with tempfile.TemporaryDirectory() as tempdir:
@@ -55,7 +56,7 @@ def _dump_archive_metadata(package_path: str,
             fd.write(json.dumps(current_packages_list, sort_keys=True, indent=4))
         if resolved_fs.exists(archive_meta_data):
             resolved_fs.rm(archive_meta_data)
-        resolved_fs.put(tempfile_path, archive_meta_data)
+        resolved_fs.put_atomic(tempfile_path, archive_meta_data)
 
 
 def upload_zip(
@@ -151,7 +152,14 @@ def upload_spec(
             dir = os.path.dirname(package_path)
             if not resolved_fs.exists(dir):
                 resolved_fs.mkdir(dir)
-            resolved_fs.put(archive_local, package_path)
+
+            if not _try_put_atomic(resolved_fs,
+                                   archive_local,
+                                   package_path,
+                                   lambda path: _is_archive_up_to_date(path, reqs, resolved_fs)):
+                raise FileExistsError(
+                    f"Package with different version exists at {package_path}"
+                )
 
             _dump_archive_metadata(package_path, reqs, resolved_fs)
     else:
@@ -174,30 +182,48 @@ def _get_hash(spec_file: str) -> str:
 
 def _upload_zip(
     zip_file: str, package_path: str,
-    resolved_fs: Any = None, force_upload: bool = False
+    resolved_fs: filesystem.EnhancedFileSystem, force_upload: bool = False
 ) -> None:
     packer = packaging.detect_packer_from_file(zip_file)
     if packer == packaging.PEX_PACKER and resolved_fs.exists(package_path):
-        with tempfile.TemporaryDirectory() as tempdir:
-            local_copy_path = os.path.join(tempdir, os.path.basename(package_path))
-            resolved_fs.get(package_path, local_copy_path)
-            info_from_storage = PexInfo.from_pex(local_copy_path)
-            into_to_upload = PexInfo.from_pex(zip_file)
-            if not force_upload and info_from_storage.code_hash == into_to_upload.code_hash:
-                _logger.info(f"skip upload of current {zip_file}"
-                             f" as it is already uploaded on {package_path}")
-                return
+        if not force_upload and _check_pex_version(resolved_fs, zip_file, package_path):
+            _logger.info(f"skip upload of current {zip_file}"
+                         f" as it is already uploaded on {package_path}")
+            return
 
     _logger.info(f"upload current {zip_file} to {package_path}")
 
     dir = os.path.dirname(package_path)
     if not resolved_fs.exists(dir):
         resolved_fs.mkdir(dir)
-    resolved_fs.put(zip_file, package_path)
+
+    if not _try_put_atomic(resolved_fs,
+                           zip_file,
+                           package_path,
+                           lambda path: _check_pex_version(resolved_fs, zip_file, path)):
+        raise FileExistsError(
+                    f"Package with different version exists at {package_path}"
+        )
+
     # Remove previous metadata
     archive_meta_data = _get_archive_metadata_path(package_path)
     if resolved_fs.exists(archive_meta_data):
         resolved_fs.rm(archive_meta_data)
+
+
+def _try_put_atomic(resolved_fs: filesystem.EnhancedFileSystem,
+                    source_path: str,
+                    destination_path: str,
+                    verify_expected_output: Callable[[str], bool]) -> bool:
+    try:
+        resolved_fs.put_atomic(source_path, destination_path)
+        return True
+    except FileExistsError:
+        if not verify_expected_output(destination_path):
+            resolved_fs.rm(destination_path)
+            resolved_fs.put_atomic(source_path, destination_path)
+            return True
+        return False
 
 
 def _handle_packages(
@@ -225,10 +251,10 @@ def _handle_packages(
 
 def _upload_env_from_venv(
         package_path: str,
-        packer: packaging.Packer = packaging.PEX_PACKER,
-        additional_packages: Dict[str, str] = {},
-        ignored_packages: Collection[str] = [],
-        resolved_fs: Any = None,
+        packer: packaging.Packer,
+        additional_packages: Dict[str, str],
+        ignored_packages: Collection[str],
+        resolved_fs: filesystem.EnhancedFileSystem,
         force_upload: bool = False,
         include_editable: bool = False
 ) -> None:
@@ -309,9 +335,27 @@ def _upload_env_from_venv(
         if not resolved_fs.exists(dir):
             resolved_fs.mkdir(dir)
         _logger.info(f'Uploading env at {local_package_path} to {package_path}')
-        resolved_fs.put(local_package_path, package_path)
+
+        if not _try_put_atomic(resolved_fs,
+                               local_package_path,
+                               package_path,
+                               lambda path: _is_archive_up_to_date(path, reqs, resolved_fs)):
+            raise FileExistsError(
+                f"Package with different version exists at {package_path}"
+            )
 
         _dump_archive_metadata(package_path, reqs, resolved_fs)
+
+
+def _check_pex_version(resolved_fs: filesystem.EnhancedFileSystem,
+                       local_package_path: str,
+                       remote_package_path: str) -> bool:
+    with tempfile.TemporaryDirectory() as tempdir:
+        local_copy_path = os.path.join(tempdir, os.path.basename(local_package_path))
+        resolved_fs.get(remote_package_path, local_copy_path)
+        into_at_destination = PexInfo.from_pex(local_copy_path)
+        info_to_upload = PexInfo.from_pex(local_package_path)
+    return info_to_upload.code_hash == into_at_destination.code_hash
 
 
 def _sort_requirements(a: List[str]) -> List[str]:

--- a/examples/spark-with-S3/scripts/run_spark_example.sh
+++ b/examples/spark-with-S3/scripts/run_spark_example.sh
@@ -3,7 +3,7 @@ rm -rf /tmp/pyspark_env
 python3.6 -m venv /tmp/pyspark_env
 . /tmp/pyspark_env/bin/activate
 pip install -U pip setuptools
-pip install pypandoc
+pip install 'pypandoc<1.8'
 # pandas pinned to < 1.0.0 because https://github.com/pantsbuild/pex/issues/1017
 pip install s3fs 'pandas<1.0.0' pyarrow==0.14.1 pyspark==2.4.4
 pip install -e /cluster-pack

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ pyarrow
 fire
 types-setuptools
 wheel-filename
+
+# Exclude faulty Protobuf version: https://github.com/protocolbuffers/protobuf/issues/10053
+protobuf!=4.21.0

--- a/tests/integration/test_skein_launcher.py
+++ b/tests/integration/test_skein_launcher.py
@@ -17,8 +17,9 @@ _logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope="module")
 def path_to_hdfs():
+    user = os.environ.get("USER")
     file_content = "Hello!"
-    path_on_hdfs = f"hdfs:///tmp/{uuid.uuid4()}"
+    path_on_hdfs = f"viewfs:///tmp/{user}/{uuid.uuid4()}"
     filepath_on_hdfs = f"{path_on_hdfs}/hello.txt"
 
     fs, _ = filesystem.resolve_filesystem_and_path(path_on_hdfs)
@@ -35,7 +36,8 @@ def path_to_hdfs():
 
 def _submit_and_await_app_master(func, assert_result_status=True, assert_log_content=None):
     with skein.Client() as client:
-        log_output_path = f"hdfs:///tmp/{uuid.uuid4()}.log"
+        user = os.environ.get("USER")
+        log_output_path = f"viewfs:///tmp/{user}/{uuid.uuid4()}.log"
         app_id = skein_launcher.submit_func(
             client,
             func=func,

--- a/tests/resources/requirements.txt
+++ b/tests/resources/requirements.txt
@@ -1,3 +1,4 @@
 cloudpickle==1.4.1
 skein
 pex>2.1.1
+protobuf!=4.21.0

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -140,3 +140,41 @@ def test_put():
 
         assert os.path.exists(remote_file)
         assert os.stat(remote_file).st_mode & 0o777 == 0o755
+
+
+def test_put_atomic():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file = f"{temp_dir}/script.sh"
+        with open(file, "wb") as f:
+            lines = ("#! /bin/bash\n"
+                     "echo 'Hello world'\n")
+            f.write(lines.encode())
+        os.chmod(file, 0o755)
+
+        fs, _ = filesystem.resolve_filesystem_and_path(file)
+
+        remote_file = f"{temp_dir}/copied_script.sh"
+        fs.put_atomic(file, remote_file)
+
+        assert os.path.exists(remote_file)
+        assert os.stat(remote_file).st_mode & 0o777 == 0o755
+
+
+def test_put_atomic_twice_fails():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file = f"{temp_dir}/script.sh"
+        with open(file, "wb") as f:
+            lines = ("#! /bin/bash\n"
+                     "echo 'Hello world'\n")
+            f.write(lines.encode())
+        os.chmod(file, 0o755)
+
+        fs, _ = filesystem.resolve_filesystem_and_path(file)
+
+        remote_file = f"{temp_dir}/copied_script.sh"
+        fs.put_atomic(file, remote_file)
+        with pytest.raises(FileExistsError):
+            fs.put_atomic(file, remote_file)
+
+        assert os.path.exists(remote_file)
+        assert os.stat(remote_file).st_mode & 0o777 == 0o755

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -169,7 +169,9 @@ def does_not_raise():
 )
 def test_pack_in_pex(pyarrow_version, expectation):
     with tempfile.TemporaryDirectory() as tempdir:
-        requirements = ["tensorflow==1.15.0", f"pyarrow=={pyarrow_version}"]
+        requirements = ["tensorflow==1.15.0",
+                        f"pyarrow=={pyarrow_version}",
+                        "protobuf!=4.21.0"]
         packaging.pack_in_pex(
             requirements,
             f"{tempdir}/out.pex",

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -242,7 +242,7 @@ def test_upload_spec_local_fs():
         assert os.path.exists(result_path)
         _check_metadata(
             f"{tempdir}/package.json",
-            ["5a5f33b106aad8584345f5a0044a4188ce78b3f4"])
+            ["e727910d1b35908cfb5880e862815d54b2fc27ab"])
 
 
 def test_upload_spec_unique_name():

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -80,14 +80,13 @@ def test_dump_metadata():
     mock_fs.exists.return_value = True
     mock_open = mock.mock_open()
     with mock.patch.object(mock_fs, 'open', mock_open):
-        mock_fs.exists.return_value = True
         packages = {"a": "1.0", "b": "2.0"}
         uploader._dump_archive_metadata(
             MYARCHIVE_FILENAME,
             packages,
             filesystem.EnhancedFileSystem(mock_fs))
         # Check previous file has been deleted
-        mock_fs.rm.assert_any_call(MYARCHIVE_METADATA)
+        mock_fs.rm.assert_called_once_with(MYARCHIVE_METADATA)
         mock_open().write.assert_called_once_with(b'{\n    "a": "1.0",\n    "b": "2.0"\n}')
 
 
@@ -120,7 +119,7 @@ def test_upload_env():
         mock_packer.assert_called_once_with(
             ["a==1.0", "b==2.0"], Any(str), [], editable_requirements={}
         )
-        mock_fs.put_atomic.assert_called_once_with(MYARCHIVE_FILENAME, MYARCHIVE_FILENAME)
+        mock_fs.put.assert_called_once_with(MYARCHIVE_FILENAME, MYARCHIVE_FILENAME)
 
         mock_packer.reset_mock()
         cluster_pack.upload_env(
@@ -200,7 +199,8 @@ def test_upload_env_in_a_pex():
 
         mock_pex_info.from_pex.side_effect = _from_pex
 
-        result = cluster_pack.upload_env(f'{home_fs_path}/blah-1.388585.133.497-review.pex')
+        result = cluster_pack.upload_env(f'{home_fs_path}/blah-1.388585.133.497-review.pex',
+                                         force_upload=True)
 
         # Check copy pex to remote
         mock_fs.put_atomic.assert_any_call(


### PR DESCRIPTION
Issue - two running process on the same user could copy their pex to the same place
Fix - put operation is slow, but remove and rename/mv are fast:
Since the expected behavior is to overwrite the destination with a newer pex, and move cannot overwrite:

- only remove if we force upload (so that we can do the final move)

- do a put to a temp destination

- rename/mv from temp to final destination

Why we do not overwrite after the put at rename/mv time if the destination exists (race condition is met):

- it would recreate a possibly inconsistent state

- we fail only if the destination is different from the file being pushed to ensure a consistent state