### PR TITLE
fix support for tag.gz extension in conda environment

### DIFF
--- a/cluster_pack/packaging.py
+++ b/cluster_pack/packaging.py
@@ -278,7 +278,7 @@ def detect_archive_names(
         package_path = (f"{get_default_fs()}/user/{getpass.getuser()}"
                         f"/envs/{env_name}.{packer.extension()}")
     else:
-        if "".join(os.path.splitext(package_path)[1]) != f".{packer.extension()}":
+        if not package_path.endswith(packer.extension()):
             raise ValueError(f"{package_path} has the wrong extension"
                              f", .{packer.extension()} is expected")
 


### PR DESCRIPTION
Hello, First time opening a PR here so don't hesitate to tell me if i'm doing something wrong.
Packaging a conda environment with the name `tensorflow.tar.gz` was broken with this PR: https://github.com/criteo/cluster-pack/commit/92dd314f4fcc9ee4ea2f036ac4fffac4bb7709eb as the parsed extension is `.gz` while the code expects `.tar.gz`.

Let me know if the explanation is not clear or if you have another solution in mind.



