### PR TITLE
Add the possibility to add an additional repo to packer

### DIFF
--- a/cluster_pack/conda.py
+++ b/cluster_pack/conda.py
@@ -74,12 +74,12 @@ def pack_venv_in_conda(
         name: str,
         reqs: List[str],
         changed_reqs: bool = False,
-        output: str = None, 
+        output: str = None,
         additional_repo: Optional[str] = None
 ) -> str:
     """
     Pack the current virtual environment
-
+    :param additional_repo: an additional pypi repo if one was used env creation
     :param reqs: directory to zip
     :param changed_reqs:
        we prefer zipping the current virtual env as much as possible,
@@ -91,7 +91,7 @@ def pack_venv_in_conda(
     if not changed_reqs:
         return conda_pack.pack(name=name, output=output)
     else:
-        return create_and_pack_conda_env(reqs=reqs, output=output,additional_repo=additional_repo)
+        return create_and_pack_conda_env(reqs=reqs, output=output, additional_repo=additional_repo)
 
 
 def create_and_pack_conda_env(
@@ -102,7 +102,7 @@ def create_and_pack_conda_env(
 ) -> str:
     """
     Create a new conda virtual environment and zip it
-
+    :param additional_repo: an additional pypi repo if one was used env creation
     :param spec_file: conda yaml spec file to use
     :param reqs: dependencies to install
     :param output: a dedicated output path
@@ -120,7 +120,12 @@ def create_and_pack_conda_env(
                 "Failed to create Python binary at " + env_python_bin)
 
         _logger.info("Installing packages into " + env_path)
-        process.call([env_python_bin, "-m", "pip", "install", '--extra-index-url', additional_repo]
-                     + reqs)
+
+        cmd = [env_python_bin, "-m", "pip", "install"]
+        if additional_repo is not None:
+            cmd.append('--extra-index-url')
+            cmd.append(additional_repo)
+
+        process.call(cmd + reqs)
 
     return conda_pack.pack(prefix=env_path, output=output, force=True)

--- a/cluster_pack/conda.py
+++ b/cluster_pack/conda.py
@@ -8,7 +8,7 @@ except NotImplementedError:
     # conda is not supported on windows
     pass
 
-from typing import List
+from typing import List, Optional
 
 from cluster_pack import process
 
@@ -74,7 +74,8 @@ def pack_venv_in_conda(
         name: str,
         reqs: List[str],
         changed_reqs: bool = False,
-        output: str = None
+        output: str = None, 
+        additional_repo: Optional[str] = None
 ) -> str:
     """
     Pack the current virtual environment
@@ -90,13 +91,14 @@ def pack_venv_in_conda(
     if not changed_reqs:
         return conda_pack.pack(name=name, output=output)
     else:
-        return create_and_pack_conda_env(reqs=reqs, output=output)
+        return create_and_pack_conda_env(reqs=reqs, output=output,additional_repo=additional_repo)
 
 
 def create_and_pack_conda_env(
     spec_file: str = None,
     reqs: List[str] = None,
-    output: str = None
+    output: str = None,
+    additional_repo: Optional[str] = None
 ) -> str:
     """
     Create a new conda virtual environment and zip it
@@ -118,6 +120,7 @@ def create_and_pack_conda_env(
                 "Failed to create Python binary at " + env_python_bin)
 
         _logger.info("Installing packages into " + env_path)
-        process.call([env_python_bin, "-m", "pip", "install"] + reqs)
+        process.call([env_python_bin, "-m", "pip", "install", '--extra-index-url', additional_repo]
+                     + reqs)
 
     return conda_pack.pack(prefix=env_path, output=output, force=True)

--- a/cluster_pack/packaging.py
+++ b/cluster_pack/packaging.py
@@ -211,12 +211,14 @@ class CondaPacker(Packer):
              reqs: List[str],
              additional_packages: Dict[str, str],
              ignored_packages: Collection[str],
-             editable_requirements:  Dict[str, str]) -> str:
+             editable_requirements:  Dict[str, str],
+             additional_repo: Optional[str]) -> str:
         return conda.pack_venv_in_conda(
                   self.env_name(),
                   reqs,
                   len(additional_packages) > 0 or len(ignored_packages) > 0,
-                  output)
+                  output,
+                  additional_repo)
 
     def pack_from_spec(self,
                        spec_file: str,

--- a/cluster_pack/packaging.py
+++ b/cluster_pack/packaging.py
@@ -104,6 +104,7 @@ def pack_in_pex(requirements: List[str],
     """
     Pack current environment using a pex.
 
+    :param additional_repo: an additional pypi repo if one was used env creation
     :param requirements: list of requirements (ex {'tensorflow': '1.15.0'})
     :param output: location of the pex
     :param ignored_packages: packages to be exluded from pex

--- a/cluster_pack/uploader.py
+++ b/cluster_pack/uploader.py
@@ -11,7 +11,8 @@ from typing import (
     Dict,
     Collection,
     List,
-    Any
+    Any,
+    Optional
 )
 from urllib import parse, request
 
@@ -88,7 +89,8 @@ def upload_env(
         ignored_packages: Collection[str] = [],
         force_upload: bool = False,
         include_editable: bool = False,
-        fs_args: Dict[str, Any] = {}
+        fs_args: Dict[str, Any] = {},
+        additional_repo: Optional[str] = None
 ) -> Tuple[str, str]:
     if packer is None:
         packer = packaging.detect_packer_from_env()
@@ -102,7 +104,8 @@ def upload_env(
             additional_packages, ignored_packages,
             resolved_fs,
             force_upload,
-            include_editable
+            include_editable,
+            additional_repo
         )
     else:
         _upload_zip(pex_file, package_path, resolved_fs, force_upload)
@@ -230,7 +233,8 @@ def _upload_env_from_venv(
         ignored_packages: Collection[str] = [],
         resolved_fs: Any = None,
         force_upload: bool = False,
-        include_editable: bool = False
+        include_editable: bool = False,
+        additional_repo: Optional[str] = None
 ) -> None:
     executable = packaging.get_current_pex_filepath() \
         if packaging._running_from_pex() else sys.executable
@@ -302,7 +306,8 @@ def _upload_env_from_venv(
                 reqs=reqs,
                 additional_packages=additional_packages,
                 ignored_packages=ignored_packages,
-                editable_requirements=editable_requirements
+                editable_requirements=editable_requirements,
+                additional_repo=additional_repo
             )
 
         dir = os.path.dirname(package_path)

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -34,7 +34,8 @@ def test_pack_venv_in_conda_changed_reqs(mock_conda_create, mock_conda_pack):
         output="testpath")
     mock_conda_pack.assert_not_called()
     mock_conda_create.assert_called_once_with(
-        reqs=["a==1.0.0", "b==2.0.0"], output="testpath")
+        reqs=["a==1.0.0", "b==2.0.0"], output="testpath",
+        additional_repo=None)
 
 
 def test_conda_env_from_reqs():

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -50,6 +50,20 @@ def test_conda_env_from_reqs():
         )
 
 
+def test_conda_env_from_reqs_with_external_repo():
+    with tempfile.TemporaryDirectory() as tempdir:
+        env_zip_path = conda.create_and_pack_conda_env(
+            reqs=["torch==1.10.1"],
+            additional_repo='https://download.pytorch.org/whl/cu113'
+        )
+        assert os.path.isfile(env_zip_path)
+
+        _check_package(
+            tempdir, env_zip_path,
+            "torch", "1.10.1+cu113"
+        )
+
+
 def test_conda_env_from_spec():
     spec_file = os.path.join(os.path.dirname(__file__), "resources", "conda.yaml")
     with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -186,6 +186,26 @@ def test_pack_in_pex(pyarrow_version, expectation):
             ))
 
 
+def test_pack_in_pex_with_additional_repo():
+    with tempfile.TemporaryDirectory() as tempdir:
+        requirements = ["torch==1.10.1.0"]
+        packaging.pack_in_pex(
+            requirements,
+            f"{tempdir}/out.pex",
+            # make isolated pex from current pytest virtual env
+            pex_inherit_path="false",
+            additional_repo="https://download.pytorch.org/whl/cu113")
+        assert os.path.exists(f"{tempdir}/out.pex")
+        with does_not_raise():
+            print(subprocess.check_output([
+                f"{tempdir}/out.pex",
+                "-c",
+                ("""print("Start importing torch..");"""
+                 """import torch;"""
+                 """print("Successfully imported torch!")""")]
+            ))
+
+
 def test_pack_in_pex_include_editable_requirements():
     requirements = {}
     requirement_dir = os.path.join(os.path.dirname(__file__), "user-lib", "user_lib")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -188,7 +188,7 @@ def test_pack_in_pex(pyarrow_version, expectation):
 
 def test_pack_in_pex_with_additional_repo():
     with tempfile.TemporaryDirectory() as tempdir:
-        requirements = ["torch==1.10.1.0"]
+        requirements = ["setuptools", "torch==1.10.1.0"]
         packaging.pack_in_pex(
             requirements,
             f"{tempdir}/out.pex",

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -117,7 +117,7 @@ def test_upload_env():
 
         cluster_pack.upload_env(MYARCHIVE_FILENAME, cluster_pack.PEX_PACKER)
         mock_packer.assert_called_once_with(
-            ["a==1.0", "b==2.0"], Any(str), [], editable_requirements={}
+            ["a==1.0", "b==2.0"], Any(str), [], additional_repo=None, editable_requirements={}
         )
         mock_fs.put.assert_called_once_with(MYARCHIVE_FILENAME, MYARCHIVE_FILENAME)
 
@@ -128,7 +128,7 @@ def test_upload_env():
             ignored_packages=["a"]
         )
         mock_packer.assert_called_once_with(
-            ["b==2.0", "c==3.0"], Any(str), ["a"], editable_requirements={}
+            ["b==2.0", "c==3.0"], Any(str), ["a"], additional_repo=None, editable_requirements={}
         )
 
 


### PR DESCRIPTION
if the venv is build with dependencies from external repos (pip --extra-index-url option), this external repo must be forwarded to pex and conda to be able to pack the venv