### PR TITLE
Fix race condition for zip upload

### DIFF
--- a/cluster_pack/filesystem.py
+++ b/cluster_pack/filesystem.py
@@ -18,6 +18,7 @@ try:
         bucket, _, _ = self.split_path(path)
         if not self.exists(bucket):
             self.mkdir(bucket)
+
     S3FileSystem.makedirs = _makedirs
 except (ModuleNotFoundError, ImportError):
     pass
@@ -30,6 +31,7 @@ def _make_function(base_fs: Any, method_name: str) -> Any:
     def f(*args: Any, **kwargs: Any) -> Any:
         func = getattr(base_fs, method_name)
         return func(*args, **kwargs)
+
     return f
 
 
@@ -41,13 +43,15 @@ def _expose_methods(child_class: Any, base_class: Any, ignored: List[str] = []) 
     :param child_class: instance of child class to add the methods to
     :param ignored: methods that will be redefined manually
     """
-    method_list = [func for func in dir(base_class)
-                   if callable(getattr(base_class, func))
-                   and not func.startswith("__")
-                   and not [f for f in ignored if func.startswith(f)]]
+    method_list = [
+        func
+        for func in dir(base_class)
+        if callable(getattr(base_class, func))
+        and not func.startswith("__")
+        and not [f for f in ignored if func.startswith(f)]
+    ]
     for method_name in method_list:
-        _logger.debug(f"add method impl from {type(base_class)}.{method_name}"
-                      f" to {type(child_class)}")
+        _logger.debug(f"add method impl from {type(base_class)}.{method_name}" f" to {type(child_class)}")
         setattr(child_class, method_name, _make_function(base_class, method_name))
 
 
@@ -67,9 +71,7 @@ def _rm(self: Any, path: str, recursive: bool = False) -> None:
 
 def _preserve_acls(base_fs: Any, local_file: str, remote_file: str) -> None:
     # this is useful for keeing pex excutable rights
-    if (isinstance(base_fs, pyarrow.filesystem.LocalFileSystem) or
-        isinstance(base_fs, pyarrow.hdfs.HadoopFileSystem)
-    ):
+    if isinstance(base_fs, pyarrow.filesystem.LocalFileSystem) or isinstance(base_fs, pyarrow.hdfs.HadoopFileSystem):
         st = os.stat(local_file)
         base_fs.chmod(remote_file, st.st_mode & 0o777)
 
@@ -77,20 +79,16 @@ def _preserve_acls(base_fs: Any, local_file: str, remote_file: str) -> None:
 
 
 class EnhancedHdfsFile(pyarrow.HdfsFile):
-
     def __init__(self, base_hdfs_file: pyarrow.HdfsFile):
         self.base_hdfs_file = base_hdfs_file
-        _expose_methods(
-            self,
-            base_hdfs_file,
-            ignored=["write", "readline", "readlines"])
+        _expose_methods(self, base_hdfs_file, ignored=["write", "readline", "readlines"])
 
     def ensure_bytes(self, s: Any) -> bytes:
         if isinstance(s, bytes):
             return s
-        if hasattr(s, 'encode'):
+        if hasattr(s, "encode"):
             return s.encode()
-        if hasattr(s, 'tobytes'):
+        if hasattr(s, "tobytes"):
             return s.tobytes()
         if isinstance(s, bytearray):
             return bytes(s)
@@ -99,8 +97,8 @@ class EnhancedHdfsFile(pyarrow.HdfsFile):
     def write(self, data: Any) -> None:
         self.base_hdfs_file.write(self.ensure_bytes(data))
 
-    def _seek_delimiter(self, delimiter: bytes, blocksize: int = 2 ** 16) -> None:
-        """ Seek current file to next byte after a delimiter
+    def _seek_delimiter(self, delimiter: bytes, blocksize: int = 2**16) -> None:
+        """Seek current file to next byte after a delimiter
         from https://github.com/dask/hdfs3/blob/master/hdfs3/utils.py#L11
 
         Parameters
@@ -110,7 +108,7 @@ class EnhancedHdfsFile(pyarrow.HdfsFile):
         blocksize: int
             number of bytes to read
         """
-        last = b''
+        last = b""
         while True:
             current = self.read(blocksize)
             if not current:
@@ -122,7 +120,7 @@ class EnhancedHdfsFile(pyarrow.HdfsFile):
                 return
             except ValueError:
                 pass
-            last = full[-len(delimiter):]
+            last = full[-len(delimiter) :]
 
     def readline(self, size: int = None) -> bytes:
         """Read and return a line of bytes from the file.
@@ -185,7 +183,6 @@ class EnhancedHdfsFile(pyarrow.HdfsFile):
 
 
 class EnhancedFileSystem(filesystem.FileSystem):
-
     def __init__(self, base_fs: Any):
         self.base_fs = base_fs
         if isinstance(base_fs, pyarrow.filesystem.LocalFileSystem):
@@ -194,8 +191,8 @@ class EnhancedFileSystem(filesystem.FileSystem):
         _expose_methods(self, base_fs, ignored=["open"])
 
     def put(self, filename: str, path: str, chunk: int = 2**16) -> None:
-        with self.base_fs.open(path, 'wb') as target:
-            with open(filename, 'rb') as source:
+        with self.base_fs.open(path, "wb") as target:
+            with open(filename, "rb") as source:
                 while True:
                     out = source.read(chunk)
                     if len(out) == 0:
@@ -204,15 +201,15 @@ class EnhancedFileSystem(filesystem.FileSystem):
         _preserve_acls(self.base_fs, filename, path)
 
     def get(self, filename: str, path: str, chunk: int = 2**16) -> None:
-        with open(path, 'wb') as target:
-            with self.base_fs.open(filename, 'rb') as source:
+        with open(path, "wb") as target:
+            with self.base_fs.open(filename, "rb") as source:
                 while True:
                     out = source.read(chunk)
                     if len(out) == 0:
                         break
                     target.write(out)
 
-    def open(self, path: str, mode: str = 'rb') -> EnhancedHdfsFile:
+    def open(self, path: str, mode: str = "rb") -> EnhancedHdfsFile:
         return EnhancedHdfsFile(self.base_fs.open(path, mode))
 
 
@@ -221,11 +218,11 @@ def resolve_filesystem_and_path(uri: str, **kwargs: Any) -> Tuple[EnhancedFileSy
     fs_path = parsed_uri.path
     # from https://github.com/apache/arrow/blob/master/python/pyarrow/filesystem.py#L419
     # with viewfs support
-    if parsed_uri.scheme == 'hdfs' or parsed_uri.scheme == 'viewfs':
-        netloc_split = parsed_uri.netloc.split(':')
+    if parsed_uri.scheme == "hdfs" or parsed_uri.scheme == "viewfs":
+        netloc_split = parsed_uri.netloc.split(":")
         host = netloc_split[0]
-        if host == '':
-            host = 'default'
+        if host == "":
+            host = "default"
         else:
             host = parsed_uri.scheme + "://" + host
         port = 0
@@ -233,7 +230,7 @@ def resolve_filesystem_and_path(uri: str, **kwargs: Any) -> Tuple[EnhancedFileSy
             port = int(netloc_split[1])
 
         fs = EnhancedFileSystem(pyarrow.hdfs.connect(host=host, port=port))
-    elif parsed_uri.scheme == 's3' or parsed_uri.scheme == 's3a':
+    elif parsed_uri.scheme == "s3" or parsed_uri.scheme == "s3a":
         fs = EnhancedFileSystem(pyarrow.filesystem.S3FSWrapper(S3FileSystem(**kwargs)))
     else:
         # Input is local path such as /home/user/myfile.parquet

--- a/cluster_pack/uploader.py
+++ b/cluster_pack/uploader.py
@@ -6,15 +6,7 @@ import os
 import sys
 import pathlib
 import tempfile
-from typing import (
-    Tuple,
-    Dict,
-    Collection,
-    List,
-    Any,
-    Optional,
-    Union
-)
+from typing import Tuple, Dict, Collection, List, Any, Optional, Union
 from urllib import parse, request
 
 from pex.pex_info import PexInfo
@@ -27,28 +19,22 @@ _logger = logging.getLogger(__name__)
 
 def _get_archive_metadata_path(package_path: str) -> str:
     url = parse.urlparse(package_path)
-    return url._replace(path=str(pathlib.Path(url.path).with_suffix('.json'))).geturl()
+    return url._replace(path=str(pathlib.Path(url.path).with_suffix(".json"))).geturl()
 
 
-def _is_archive_up_to_date(package_path: str,
-                           current_packages_list: List[str],
-                           resolved_fs: Any = None
-                           ) -> bool:
+def _is_archive_up_to_date(package_path: str, current_packages_list: List[str], resolved_fs: Any = None) -> bool:
     if not resolved_fs.exists(package_path):
         return False
     archive_meta_data = _get_archive_metadata_path(package_path)
     if not resolved_fs.exists(archive_meta_data):
-        _logger.debug(f'metadata for archive {package_path} does not exist')
+        _logger.debug(f"metadata for archive {package_path} does not exist")
         return False
     with resolved_fs.open(archive_meta_data, "rb") as fd:
         packages_installed = json.loads(fd.read())
         return sorted(packages_installed) == sorted(current_packages_list)
 
 
-def _dump_archive_metadata(package_path: str,
-                           current_packages_list: List[str],
-                           resolved_fs: Any = None
-                           ) -> None:
+def _dump_archive_metadata(package_path: str, current_packages_list: List[str], resolved_fs: Any = None) -> None:
     archive_meta_data = _get_archive_metadata_path(package_path)
     with tempfile.TemporaryDirectory() as tempdir:
         tempfile_path = os.path.join(tempdir, "metadata.json")
@@ -60,10 +46,7 @@ def _dump_archive_metadata(package_path: str,
 
 
 def upload_zip(
-        zip_file: str,
-        package_path: str = None,
-        force_upload: bool = False,
-        fs_args: Dict[str, Any] = {}
+    zip_file: str, package_path: str = None, force_upload: bool = False, fs_args: Dict[str, Any] = {}
 ) -> str:
     packer = packaging.detect_packer_from_file(zip_file)
     package_path, _, _ = packaging.detect_archive_names(packer, package_path)
@@ -83,16 +66,16 @@ def upload_zip(
 
 
 def upload_env(
-        package_path: str = None,
-        packer: packaging.Packer = None,
-        additional_packages: Dict[str, str] = {},
-        ignored_packages: Collection[str] = [],
-        force_upload: bool = False,
-        include_editable: bool = False,
-        fs_args: Dict[str, Any] = {},
-        allow_large_pex: bool = False,
-        additional_repo: Optional[Union[str, List[str]]] = None,
-        additional_indexes: Optional[List[str]] = None
+    package_path: str = None,
+    packer: packaging.Packer = None,
+    additional_packages: Dict[str, str] = {},
+    ignored_packages: Collection[str] = [],
+    force_upload: bool = False,
+    include_editable: bool = False,
+    fs_args: Dict[str, Any] = {},
+    allow_large_pex: bool = False,
+    additional_repo: Optional[Union[str, List[str]]] = None,
+    additional_indexes: Optional[List[str]] = None,
 ) -> Tuple[str, str]:
     """Upload current python env.
 
@@ -115,35 +98,36 @@ def upload_env(
     """
     if packer is None:
         packer = packaging.detect_packer_from_env()
-    package_path, env_name, pex_file = \
-        packaging.detect_archive_names(packer, package_path, allow_large_pex)
+    package_path, env_name, pex_file = packaging.detect_archive_names(packer, package_path, allow_large_pex)
 
     resolved_fs, _ = filesystem.resolve_filesystem_and_path(package_path, **fs_args)
 
     if pex_file == "":
         _upload_env_from_venv(
-            package_path, packer,
-            additional_packages, ignored_packages,
+            package_path,
+            packer,
+            additional_packages,
+            ignored_packages,
             resolved_fs,
             force_upload,
             include_editable,
             allow_large_pex=allow_large_pex,
             additional_repo=additional_repo,
-            additional_indexes=additional_indexes
+            additional_indexes=additional_indexes,
         )
     else:
         _upload_zip(pex_file, package_path, resolved_fs, force_upload)
 
-    return (package_path,
-            env_name)
+    return (package_path, env_name)
 
 
 def upload_spec(
-        spec_file: str,
-        package_path: str = None,
-        force_upload: bool = False,
-        fs_args: Dict[str, Any] = {},
-        allow_large_pex: bool = False) -> str:
+    spec_file: str,
+    package_path: str = None,
+    force_upload: bool = False,
+    fs_args: Dict[str, Any] = {},
+    allow_large_pex: bool = False,
+) -> str:
     """Upload an environment from a spec file
 
     :param spec_file: the spec file, must be requirements.txt or conda.yaml
@@ -157,15 +141,14 @@ def upload_spec(
     """
     packer = packaging.detect_packer_from_spec(spec_file)
     if not package_path:
-        package_path = (f"{packaging.get_default_fs()}/user/{getpass.getuser()}"
-                        f"/envs/{_unique_filename(spec_file, packer)}")
+        package_path = (
+            f"{packaging.get_default_fs()}/user/{getpass.getuser()}" f"/envs/{_unique_filename(spec_file, packer)}"
+        )
     elif not package_path.endswith(packer.extension()):
         package_path = os.path.join(package_path, _unique_filename(spec_file, packer))
 
-    if (packer.extension() == packaging.PEX_PACKER.extension()
-            and allow_large_pex
-            and not package_path.endswith('.zip')):
-        package_path += '.zip'
+    if packer.extension() == packaging.PEX_PACKER.extension() and allow_large_pex and not package_path.endswith(".zip"):
+        package_path += ".zip"
 
     resolved_fs, path = filesystem.resolve_filesystem_and_path(package_path, **fs_args)
 
@@ -175,15 +158,14 @@ def upload_spec(
 
     up_to_date = _is_archive_up_to_date(package_path, reqs, resolved_fs)
     if force_upload or not up_to_date:
-        _logger.info(
-            f"Zipping and uploading your env to {package_path}"
-        )
+        _logger.info(f"Zipping and uploading your env to {package_path}")
 
         with tempfile.TemporaryDirectory() as tempdir:
             archive_local = packer.pack_from_spec(
                 spec_file=spec_file,
                 output=f"{tempdir}/{packer.env_name()}.{packer.extension()}",
-                allow_large_pex=allow_large_pex)
+                allow_large_pex=allow_large_pex,
+            )
 
             dir = os.path.dirname(package_path)
             if not resolved_fs.exists(dir):
@@ -209,10 +191,7 @@ def _get_hash(spec_file: str) -> str:
         return hashlib.sha1(f.read().encode()).hexdigest()
 
 
-def _upload_zip(
-        zip_file: str, package_path: str,
-        resolved_fs: Any = None, force_upload: bool = False
-) -> None:
+def _upload_zip(zip_file: str, package_path: str, resolved_fs: Any = None, force_upload: bool = False) -> None:
     packer = packaging.detect_packer_from_file(zip_file)
     if packer == packaging.PEX_PACKER and resolved_fs.exists(package_path):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -221,8 +200,7 @@ def _upload_zip(
             info_from_storage = PexInfo.from_pex(local_copy_path)
             info_to_upload = PexInfo.from_pex(zip_file)
             if not force_upload and info_from_storage.code_hash == info_to_upload.code_hash:
-                _logger.info(f"skip upload of current {zip_file}"
-                             f" as it is already uploaded on {package_path}")
+                _logger.info(f"skip upload of current {zip_file}" f" as it is already uploaded on {package_path}")
                 return
 
     _logger.info(f"upload current {zip_file} to {package_path}")
@@ -238,9 +216,7 @@ def _upload_zip(
 
 
 def _handle_packages(
-        current_packages: Dict[str, str],
-        additional_packages: Dict[str, str] = {},
-        ignored_packages: Collection[str] = []
+    current_packages: Dict[str, str], additional_packages: Dict[str, str] = {}, ignored_packages: Collection[str] = []
 ) -> None:
     if len(additional_packages) > 0:
         additional_package_names = list(additional_packages.keys())
@@ -261,26 +237,21 @@ def _handle_packages(
 
 
 def _upload_env_from_venv(
-        package_path: str,
-        packer: packaging.Packer = packaging.PEX_PACKER,
-        additional_packages: Dict[str, str] = {},
-        ignored_packages: Collection[str] = [],
-        resolved_fs: Any = None,
-        force_upload: bool = False,
-        include_editable: bool = False,
-        allow_large_pex: bool = False,
-        additional_repo: Optional[Union[str, List[str]]] = None,
-        additional_indexes: Optional[List[str]] = None
+    package_path: str,
+    packer: packaging.Packer = packaging.PEX_PACKER,
+    additional_packages: Dict[str, str] = {},
+    ignored_packages: Collection[str] = [],
+    resolved_fs: Any = None,
+    force_upload: bool = False,
+    include_editable: bool = False,
+    allow_large_pex: bool = False,
+    additional_repo: Optional[Union[str, List[str]]] = None,
+    additional_indexes: Optional[List[str]] = None,
 ) -> None:
-    executable = packaging.get_current_pex_filepath() \
-        if packaging._running_from_pex() else sys.executable
+    executable = packaging.get_current_pex_filepath() if packaging._running_from_pex() else sys.executable
     current_packages = packaging.get_non_editable_requirements(executable)
 
-    _handle_packages(
-        current_packages,
-        additional_packages,
-        ignored_packages
-    )
+    _handle_packages(current_packages, additional_packages, ignored_packages)
 
     reqs = packaging.format_requirements(current_packages)
 
@@ -292,11 +263,11 @@ def _upload_env_from_venv(
 
     with tempfile.TemporaryDirectory() as tempdir:
         env_copied_from_fallback_location = False
-        local_package_path = f'{tempdir}/{packer.env_name()}.{packer.extension()}'
+        local_package_path = f"{tempdir}/{packer.env_name()}.{packer.extension()}"
         local_fs, local_package_path = filesystem.resolve_filesystem_and_path(local_package_path)
 
-        fallback_path = os.environ.get('C_PACK_ENV_FALLBACK_PATH')
-        if not force_upload and fallback_path and packer.extension() == 'pex':
+        fallback_path = os.environ.get("C_PACK_ENV_FALLBACK_PATH")
+        if not force_upload and fallback_path and packer.extension() == "pex":
             _logger.info(f"Copying pre-built env from {fallback_path} to {local_package_path}")
             if fallback_path.startswith("http://") or fallback_path.startswith("https://"):
                 request.urlretrieve(fallback_path, local_package_path)
@@ -304,31 +275,23 @@ def _upload_env_from_venv(
                 fallback_fs, fallback_path = filesystem.resolve_filesystem_and_path(fallback_path)
                 fallback_fs.get(fallback_path, local_package_path)
 
-            _logger.info(f'Checking requirements in {local_package_path}')
+            _logger.info(f"Checking requirements in {local_package_path}")
 
             pex_info = PexInfo.from_pex(local_package_path)
 
             req_from_pex = _filter_out_requirements(
-                _sort_requirements(
-                    _normalize_requirements(
-                        _format_pex_requirements(pex_info)
-                    )
-                )
+                _sort_requirements(_normalize_requirements(_format_pex_requirements(pex_info)))
             )
-            req_from_venv = _filter_out_requirements(
-                _sort_requirements(
-                    _normalize_requirements(reqs)
-                )
-            )
+            req_from_venv = _filter_out_requirements(_sort_requirements(_normalize_requirements(reqs)))
 
-            if (req_from_pex == req_from_venv):
+            if req_from_pex == req_from_venv:
                 env_copied_from_fallback_location = True
                 _dump_archive_metadata(local_package_path, reqs, local_fs)
-                _logger.info('Env copied from fallback location')
+                _logger.info("Env copied from fallback location")
             else:
-                _logger.warning(f'Requirements not met for pre-built {local_package_path}')
-                _logger.info(f'Requirements from pex {req_from_pex}')
-                _logger.info(f'Requirements from venv {req_from_venv}')
+                _logger.warning(f"Requirements not met for pre-built {local_package_path}")
+                _logger.info(f"Requirements from pex {req_from_pex}")
+                _logger.info(f"Requirements from venv {req_from_venv}")
 
         if not env_copied_from_fallback_location:
             if include_editable:
@@ -345,13 +308,13 @@ def _upload_env_from_venv(
                 editable_requirements=editable_requirements,
                 allow_large_pex=allow_large_pex,
                 additional_repo=additional_repo,
-                additional_indexes=additional_indexes
+                additional_indexes=additional_indexes,
             )
 
         dir = os.path.dirname(package_path)
         if not resolved_fs.exists(dir):
             resolved_fs.mkdir(dir)
-        _logger.info(f'Uploading env at {local_package_path} to {package_path}')
+        _logger.info(f"Uploading env at {local_package_path} to {package_path}")
         resolved_fs.put(local_package_path, package_path)
 
         _dump_archive_metadata(package_path, reqs, resolved_fs)
@@ -367,7 +330,7 @@ def _format_pex_requirements(pex_info: PexInfo) -> List[str]:
 
 
 def _normalize_requirements(reqs: List[str]) -> List[str]:
-    return [req.replace('_', '-') for req in reqs]
+    return [req.replace("_", "-") for req in reqs]
 
 
 def _filter_out_requirements(reqs: List[str]) -> List[str]:

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -133,3 +133,41 @@ def test_put():
 
         assert os.path.exists(remote_file)
         assert os.stat(remote_file).st_mode & 0o777 == 0o755
+
+
+def test_put_atomic():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file = f"{temp_dir}/script.sh"
+        with open(file, "wb") as f:
+            lines = ("#! /bin/bash\n"
+                     "echo 'Hello world'\n")
+            f.write(lines.encode())
+        os.chmod(file, 0o755)
+
+        fs, _ = filesystem.resolve_filesystem_and_path(file)
+
+        remote_file = f"{temp_dir}/copied_script.sh"
+        fs.put_atomic(file, remote_file)
+
+        assert os.path.exists(remote_file)
+        assert os.stat(remote_file).st_mode & 0o777 == 0o755
+
+
+def test_put_atomic_twice_fails():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file = f"{temp_dir}/script.sh"
+        with open(file, "wb") as f:
+            lines = ("#! /bin/bash\n"
+                     "echo 'Hello world'\n")
+            f.write(lines.encode())
+        os.chmod(file, 0o755)
+
+        fs, _ = filesystem.resolve_filesystem_and_path(file)
+
+        remote_file = f"{temp_dir}/copied_script.sh"
+        fs.put_atomic(file, remote_file)
+        with pytest.raises(FileExistsError):
+            fs.put_atomic(file, remote_file)
+
+        assert os.path.exists(remote_file)
+        assert os.stat(remote_file).st_mode & 0o777 == 0o755

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -5,12 +5,7 @@ import tempfile
 from cluster_pack import filesystem
 
 
-lines = ("abcdef\n"
-         "\n"
-         "\n"
-         "123456789\n"
-         "\n"
-         "\n")
+lines = "abcdef\n" "\n" "\n" "123456789\n" "\n" "\n"
 
 
 def _create_temp_file(temp_dir: str, filename: str = "myfile.txt"):
@@ -27,7 +22,7 @@ def _create_temp_file(temp_dir: str, filename: str = "myfile.txt"):
         (3, b"abc"),
         (7, b"abcdef\n"),
         (10, b"abcdef\n"),
-    ]
+    ],
 )
 def test_readline(size, expected_line):
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -44,10 +39,10 @@ def test_readline(size, expected_line):
     "size,expected_lines",
     [
         (None, [b"abcdef\n", b"\n", b"\n", b"123456789\n", b"\n", b"\n"]),
-        (3, [b'abcdef\n']),
-        (7, [b'abcdef\n', b'\n']),
+        (3, [b"abcdef\n"]),
+        (7, [b"abcdef\n", b"\n"]),
         (10, [b"abcdef\n", b"\n", b"\n", b"123456789\n"]),
-    ]
+    ],
 )
 def test_readlines(size, expected_lines):
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -89,8 +84,7 @@ def test_chmod():
     with tempfile.TemporaryDirectory() as temp_dir:
         file = f"{temp_dir}/script.sh"
         with open(file, "wb") as f:
-            lines = ("#! /bin/bash\n"
-                     "echo 'Hello world'\n")
+            lines = "#! /bin/bash\n" "echo 'Hello world'\n"
             f.write(lines.encode())
 
         fs, _ = filesystem.resolve_filesystem_and_path(file)
@@ -128,8 +122,7 @@ def test_put():
     with tempfile.TemporaryDirectory() as temp_dir:
         file = f"{temp_dir}/script.sh"
         with open(file, "wb") as f:
-            lines = ("#! /bin/bash\n"
-                     "echo 'Hello world'\n")
+            lines = "#! /bin/bash\n" "echo 'Hello world'\n"
             f.write(lines.encode())
         os.chmod(file, 0o755)
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -72,10 +72,10 @@ expected_file = """\
 def test_dump_metadata():
     mock_fs = mock.Mock()
     mock_fs.rm.return_value = True
+    mock_fs.rename.return_value = True
     mock_fs.exists.return_value = True
     mock_open = mock.mock_open()
     with mock.patch.object(mock_fs, "open", mock_open):
-        mock_fs.exists.return_value = True
         packages = {"a": "1.0", "b": "2.0"}
         uploader._dump_archive_metadata(MYARCHIVE_FILENAME, packages, filesystem.EnhancedFileSystem(mock_fs))
         # Check previous file has been deleted
@@ -148,7 +148,7 @@ def test_upload_zip():
                 result = cluster_pack.upload_zip("http://myserver/mypex.pex", f"{home_fs_path}/blah.pex")
 
                 mock_request.urlretrieve.assert_called_once_with("http://myserver/mypex.pex", "/tmp/mypex.pex")
-                mock_fs.put.assert_any_call("/tmp/mypex.pex", f"{home_fs_path}/blah.pex")
+                mock_fs.put_atomic.assert_any_call("/tmp/mypex.pex", f"{home_fs_path}/blah.pex")
 
                 assert "/user/j.doe/blah.pex" == result
 
@@ -184,12 +184,12 @@ def test_upload_env_in_a_pex():
 
         mock_pex_info.from_pex.side_effect = _from_pex
 
-        result = cluster_pack.upload_env(f"{home_fs_path}/blah-1.388585.133.497-review.pex")
+        result = cluster_pack.upload_env(f"{home_fs_path}/blah-1.388585.133.497-review.pex", force_upload=True)
 
         # Check copy pex to remote
-        mock_fs.put.assert_any_call(f"{home_path}/myapp.pex", f"{home_fs_path}/blah-1.388585.133.497-review.pex")
+        mock_fs.put_atomic.assert_any_call(f"{home_path}/myapp.pex", f"{home_fs_path}/blah-1.388585.133.497-review.pex")
         # Check metadata has been cleaned
-        mock_fs.rm.assert_called_once_with(f"{home_fs_path}/blah-1.388585.133.497-review.json")
+        mock_fs.rm.assert_any_call(f"{home_fs_path}/blah-1.388585.133.497-review.json")
         # check envname
         assert "myapp" == result[1]
 
@@ -231,57 +231,71 @@ def test_upload_spec_local_fs():
 
 def test_upload_spec_unique_name():
     with tempfile.TemporaryDirectory() as tempdir:
-        spec_file = f"{tempdir}/myproject/requirements.txt"
-        _write_spec_file(spec_file, ["cloudpickle==1.4.1"])
+        with tempfile.TemporaryDirectory() as tempdestination:
 
-        result_path = cluster_pack.upload_spec(spec_file, f"{tempdir}")
+            spec_file = f"{tempdir}/myproject/requirements.txt"
+            _write_spec_file(spec_file, ["cloudpickle==1.4.1"])
 
-        assert os.path.exists(result_path)
-        assert result_path == f"{tempdir}/cluster_pack_myproject.pex"
-        _check_metadata(f"{tempdir}/cluster_pack_myproject.json", ["b8721a3c125d3f7edfa27d7b13236e696f652a16"])
+            result_path = cluster_pack.upload_spec(spec_file, f"{tempdestination}")
+
+            assert os.path.exists(result_path)
+            assert result_path == f"{tempdestination}/cluster_pack_myproject.pex"
+            _check_metadata(
+                f"{tempdestination}/cluster_pack_myproject.json", ["b8721a3c125d3f7edfa27d7b13236e696f652a16"]
+            )
+
+            assert os.path.exists(result_path)
+            assert result_path == f"{tempdestination}/cluster_pack_myproject.pex"
+            _check_metadata(
+                f"{tempdestination}/cluster_pack_myproject.json", ["b8721a3c125d3f7edfa27d7b13236e696f652a16"]
+            )
 
 
-@mock.patch(f"{MODULE_TO_TEST}.packaging.pack_spec_in_pex")
-def test_upload_spec_local_fs_use_cache(mock_pack_spec_in_pex):
+def test_upload_spec_local_fs_use_cache():
     with tempfile.TemporaryDirectory() as tempdir:
-        spec_file = f"{tempdir}/myproject/requirements.txt"
-        _write_spec_file(spec_file, ["cloudpickle==1.4.1"])
+        with tempfile.TemporaryDirectory() as tempdestination:
+            spec_file = f"{tempdir}/myproject/requirements.txt"
+            _write_spec_file(spec_file, ["cloudpickle==1.4.1", "protobuf!=4.21.0"])
 
-        pex_file = os.path.join(tempdir, "package.pex")
-        mock_pack_spec_in_pex.return_value = pex_file
-        with open(pex_file, "w"):
-            pass
+            pex_file = os.path.join(tempdir, "package.pex")
+            packer = packaging.detect_packer_from_spec(spec_file)
+            packer.pack_from_spec(spec_file, pex_file)
+            pex_destination = os.path.join(tempdestination, "package.pex")
 
-        result_path = cluster_pack.upload_spec(spec_file, pex_file)
-        result_path1 = cluster_pack.upload_spec(spec_file, pex_file)
+            result_path = cluster_pack.upload_spec(spec_file, pex_destination)
 
-        mock_pack_spec_in_pex.assert_called_once()
-        assert os.path.exists(result_path)
-        assert result_path == result_path1 == pex_file
+            _check_metadata(f"{tempdestination}/package.json", ["7125c2af3445cb80cb26b422a9682320442c9028"])
+
+            result_path1 = cluster_pack.upload_spec(spec_file, pex_destination)
+
+            assert os.path.exists(result_path)
+            assert result_path == result_path1
+            assert result_path.startswith(tempdestination)
+            _check_metadata(f"{tempdestination}/package.json", ["7125c2af3445cb80cb26b422a9682320442c9028"])
 
 
-@mock.patch(f"{MODULE_TO_TEST}.packaging.pack_spec_in_pex")
-def test_upload_spec_local_fs_changed_reqs(mock_pack_spec_in_pex):
-    mock_pack_spec_in_pex.return_value = "/tmp/tmp.pex"
+def test_upload_spec_local_fs_changed_reqs():
     with tempfile.TemporaryDirectory() as tempdir:
-        spec_file = f"{tempdir}/myproject/requirements.txt"
-        _write_spec_file(spec_file, ["cloudpickle==1.4.1"])
+        with tempfile.TemporaryDirectory() as tempdestination:
+            spec_file = f"{tempdir}/myproject/requirements.txt"
+            _write_spec_file(spec_file, ["cloudpickle==1.4.1", "protobuf!=4.21.0"])
 
-        pex_file = os.path.join(tempdir, "package.pex")
-        mock_pack_spec_in_pex.return_value = pex_file
-        with open(pex_file, "w") as f:
-            pass
+            pex_file = os.path.join(tempdir, "package.pex")
+            packer = packaging.detect_packer_from_spec(spec_file)
+            packer.pack_from_spec(spec_file, pex_file)
+            pex_destination = os.path.join(tempdestination, "package.pex")
 
-        result_path = cluster_pack.upload_spec(spec_file, pex_file)
+            result_path = cluster_pack.upload_spec(spec_file, pex_destination)
+            assert os.path.exists(result_path)
+            _check_metadata(f"{tempdestination}/package.json", ["7125c2af3445cb80cb26b422a9682320442c9028"])
 
-        with open(spec_file, "a") as f:
-            f.write("skein\n")
+            with open(spec_file, "a") as f:
+                f.write("skein\n")
 
-        result_path1 = cluster_pack.upload_spec(spec_file, pex_file)
-        mock_pack_spec_in_pex.call_count == 2
-        assert os.path.exists(result_path)
-        assert os.path.exists(result_path1)
-        _check_metadata(f"{tempdir}/package.json", ["0fd17ced922a2387fa660fb0cb78e1c77fbe3349"])
+            result_path1 = cluster_pack.upload_spec(spec_file, pex_destination)
+
+            assert os.path.exists(result_path1)
+            _check_metadata(f"{tempdestination}/package.json", ["0de429cdde24230ba3c0ad29d3d13618ad9f90b4"])
 
 
 def test__handle_packages_use_local_wheel():

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -25,44 +25,40 @@ def test_update_no_archive():
 
 
 def test_update_no_metadata():
-    map_is_exist = {MYARCHIVE_FILENAME: True,
-                    MYARCHIVE_METADATA: False}
+    map_is_exist = {MYARCHIVE_FILENAME: True, MYARCHIVE_METADATA: False}
     mock_fs = mock.MagicMock()
     mock_fs.exists = lambda arg: map_is_exist[arg]
     assert not uploader._is_archive_up_to_date(MYARCHIVE_FILENAME, [], mock_fs)
 
 
-@pytest.mark.parametrize("current_packages, metadata_packages, expected", [
-    pytest.param(["a==2.0", "b==1.0"], ["a==2.0", "b==1.0"], True),
-    pytest.param(["a==2.0", "b==1.0"], ["a==1.0", "b==1.0"], False),
-    pytest.param(["a==2.0", "b==1.0"], ["a==2.0"], False),
-    pytest.param(["a==2.0"], ["a==2.0", "b==1.0"], False),
-    pytest.param([], ["a==2.0", "b==1.0"], False),
-    pytest.param(["a==2.0"], ["c==1.0"], False),
-    pytest.param([], [], True),
-])
-def test_update_version_comparaison(current_packages, metadata_packages,
-                                    expected):
+@pytest.mark.parametrize(
+    "current_packages, metadata_packages, expected",
+    [
+        pytest.param(["a==2.0", "b==1.0"], ["a==2.0", "b==1.0"], True),
+        pytest.param(["a==2.0", "b==1.0"], ["a==1.0", "b==1.0"], False),
+        pytest.param(["a==2.0", "b==1.0"], ["a==2.0"], False),
+        pytest.param(["a==2.0"], ["a==2.0", "b==1.0"], False),
+        pytest.param([], ["a==2.0", "b==1.0"], False),
+        pytest.param(["a==2.0"], ["c==1.0"], False),
+        pytest.param([], [], True),
+    ],
+)
+def test_update_version_comparaison(current_packages, metadata_packages, expected):
 
-    map_is_exist = {MYARCHIVE_FILENAME: True,
-                    MYARCHIVE_METADATA: True}
+    map_is_exist = {MYARCHIVE_FILENAME: True, MYARCHIVE_METADATA: True}
 
     mock_fs = mock.MagicMock()
     mock_fs.exists = lambda arg: map_is_exist[arg]
 
-    with mock.patch.object(
-        mock_fs, 'open', mock.mock_open(read_data=json.dumps(metadata_packages))
-    ):
-        assert uploader._is_archive_up_to_date(
-            MYARCHIVE_FILENAME,
-            current_packages,
-            mock_fs) == expected
+    with mock.patch.object(mock_fs, "open", mock.mock_open(read_data=json.dumps(metadata_packages))):
+        assert uploader._is_archive_up_to_date(MYARCHIVE_FILENAME, current_packages, mock_fs) == expected
 
 
 def Any(cls):
     class Any(cls):
         def __eq__(self, other):
             return isinstance(other, cls)
+
     return Any()
 
 
@@ -78,13 +74,10 @@ def test_dump_metadata():
     mock_fs.rm.return_value = True
     mock_fs.exists.return_value = True
     mock_open = mock.mock_open()
-    with mock.patch.object(mock_fs, 'open', mock_open):
+    with mock.patch.object(mock_fs, "open", mock_open):
         mock_fs.exists.return_value = True
         packages = {"a": "1.0", "b": "2.0"}
-        uploader._dump_archive_metadata(
-            MYARCHIVE_FILENAME,
-            packages,
-            filesystem.EnhancedFileSystem(mock_fs))
+        uploader._dump_archive_metadata(MYARCHIVE_FILENAME, packages, filesystem.EnhancedFileSystem(mock_fs))
         # Check previous file has been deleted
         mock_fs.rm.assert_called_once_with(MYARCHIVE_METADATA)
         mock_open().write.assert_called_once_with(b'{\n    "a": "1.0",\n    "b": "2.0"\n}')
@@ -93,44 +86,46 @@ def test_dump_metadata():
 def test_upload_env():
     with contextlib.ExitStack() as stack:
         # Mock all objects
-        mock_is_archive = stack.enter_context(
-                mock.patch(f"{MODULE_TO_TEST}._is_archive_up_to_date"))
-        mock_get_packages = stack.enter_context(
-                mock.patch(f"{MODULE_TO_TEST}.packaging.get_non_editable_requirements"))
+        mock_is_archive = stack.enter_context(mock.patch(f"{MODULE_TO_TEST}._is_archive_up_to_date"))
+        mock_get_packages = stack.enter_context(mock.patch(f"{MODULE_TO_TEST}.packaging.get_non_editable_requirements"))
 
-        mock_resolve_fs = stack.enter_context(
-            mock.patch(f"{MODULE_TO_TEST}.filesystem.resolve_filesystem_and_path"))
+        mock_resolve_fs = stack.enter_context(mock.patch(f"{MODULE_TO_TEST}.filesystem.resolve_filesystem_and_path"))
         mock_fs = mock.MagicMock()
         mock_resolve_fs.return_value = mock_fs, ""
 
         stack.enter_context(mock.patch(f"{MODULE_TO_TEST}._dump_archive_metadata"))
-        mock_packer = stack.enter_context(
-            mock.patch(f"{MODULE_TO_TEST}.packaging.pack_in_pex")
-        )
+        mock_packer = stack.enter_context(mock.patch(f"{MODULE_TO_TEST}.packaging.pack_in_pex"))
 
         # Regenerate archive
         mock_is_archive.return_value = False
-        mock_get_packages.return_value = {"a": "1.0",
-                                          "b": "2.0"}
+        mock_get_packages.return_value = {"a": "1.0", "b": "2.0"}
 
         mock_packer.return_value = MYARCHIVE_FILENAME
 
         cluster_pack.upload_env(MYARCHIVE_FILENAME, cluster_pack.PEX_PACKER)
         mock_packer.assert_called_once_with(
-            ["a==1.0", "b==2.0"], Any(str), [], additional_indexes=None, additional_repo=None,
-            allow_large_pex=False, editable_requirements={}
+            ["a==1.0", "b==2.0"],
+            Any(str),
+            [],
+            additional_indexes=None,
+            additional_repo=None,
+            allow_large_pex=False,
+            editable_requirements={},
         )
         mock_fs.put.assert_called_once_with(MYARCHIVE_FILENAME, MYARCHIVE_FILENAME)
 
         mock_packer.reset_mock()
         cluster_pack.upload_env(
-            MYARCHIVE_FILENAME, cluster_pack.PEX_PACKER,
-            additional_packages={"c": "3.0"},
-            ignored_packages=["a"]
+            MYARCHIVE_FILENAME, cluster_pack.PEX_PACKER, additional_packages={"c": "3.0"}, ignored_packages=["a"]
         )
         mock_packer.assert_called_once_with(
-            ["b==2.0", "c==3.0"], Any(str), ["a"], additional_indexes=None, additional_repo=None,
-            allow_large_pex=False, editable_requirements={}
+            ["b==2.0", "c==3.0"],
+            Any(str),
+            ["a"],
+            additional_indexes=None,
+            additional_repo=None,
+            allow_large_pex=False,
+            editable_requirements={},
         )
 
 
@@ -140,9 +135,8 @@ def test_upload_env_should_throw_error_if_wrong_extension():
 
 
 def test_upload_zip():
-    home_fs_path = '/user/j.doe'
-    with mock.patch(
-            f"{MODULE_TO_TEST}.filesystem.resolve_filesystem_and_path") as mock_resolve_fs:
+    home_fs_path = "/user/j.doe"
+    with mock.patch(f"{MODULE_TO_TEST}.filesystem.resolve_filesystem_and_path") as mock_resolve_fs:
         mock_fs = mock.MagicMock()
         mock_resolve_fs.return_value = mock_fs, ""
         with mock.patch(f"{MODULE_TO_TEST}.request") as mock_request:
@@ -151,66 +145,53 @@ def test_upload_zip():
                 mock_fs.exists.return_value = False
                 mock_tempfile.TemporaryDirectory.return_value.__enter__.return_value = "/tmp"
 
-                result = cluster_pack.upload_zip(
-                    "http://myserver/mypex.pex",
-                    f"{home_fs_path}/blah.pex"
-                )
+                result = cluster_pack.upload_zip("http://myserver/mypex.pex", f"{home_fs_path}/blah.pex")
 
-                mock_request.urlretrieve.assert_called_once_with(
-                    "http://myserver/mypex.pex",
-                    "/tmp/mypex.pex")
+                mock_request.urlretrieve.assert_called_once_with("http://myserver/mypex.pex", "/tmp/mypex.pex")
                 mock_fs.put.assert_any_call("/tmp/mypex.pex", f"{home_fs_path}/blah.pex")
 
                 assert "/user/j.doe/blah.pex" == result
 
 
 def test_upload_env_in_a_pex():
-    home_path = '/home/j.doe'
-    home_fs_path = '/user/j.doe'
+    home_path = "/home/j.doe"
+    home_fs_path = "/user/j.doe"
     with contextlib.ExitStack() as stack:
-        mock_running_from_pex = stack.enter_context(
-            mock.patch(f"{MODULE_TO_TEST}.packaging._running_from_pex"))
+        mock_running_from_pex = stack.enter_context(mock.patch(f"{MODULE_TO_TEST}.packaging._running_from_pex"))
         mock_running_from_pex.return_value = True
-        mock_pex_filepath = stack.enter_context(
-            mock.patch(f"{MODULE_TO_TEST}.packaging.get_current_pex_filepath"))
+        mock_pex_filepath = stack.enter_context(mock.patch(f"{MODULE_TO_TEST}.packaging.get_current_pex_filepath"))
         mock_pex_filepath.return_value = f"{home_path}/myapp.pex"
 
-        mock_resolve_fs = stack.enter_context(
-            mock.patch(f"{MODULE_TO_TEST}.filesystem.resolve_filesystem_and_path"))
+        mock_resolve_fs = stack.enter_context(mock.patch(f"{MODULE_TO_TEST}.filesystem.resolve_filesystem_and_path"))
         mock_fs = mock.MagicMock()
         mock_resolve_fs.return_value = mock_fs, ""
 
         mock__get_archive_metadata_path = stack.enter_context(
             mock.patch(f"{MODULE_TO_TEST}._get_archive_metadata_path")
         )
-        mock__get_archive_metadata_path.return_value = \
-            f"{home_fs_path}/blah-1.388585.133.497-review.json"
+        mock__get_archive_metadata_path.return_value = f"{home_fs_path}/blah-1.388585.133.497-review.json"
 
         # metadata & pex already exists on fs
         mock_fs.exists.return_value = True
 
-        mock_pex_info = stack.enter_context(
-            mock.patch(f"{MODULE_TO_TEST}.PexInfo")
-        )
+        mock_pex_info = stack.enter_context(mock.patch(f"{MODULE_TO_TEST}.PexInfo"))
 
         def _from_pex(arg):
-            if arg == f'{home_path}/myapp.pex':
+            if arg == f"{home_path}/myapp.pex":
                 return PexInfo({"code_hash": 1})
             else:
                 return PexInfo({"code_hash": 2})
 
         mock_pex_info.from_pex.side_effect = _from_pex
 
-        result = cluster_pack.upload_env(f'{home_fs_path}/blah-1.388585.133.497-review.pex')
+        result = cluster_pack.upload_env(f"{home_fs_path}/blah-1.388585.133.497-review.pex")
 
         # Check copy pex to remote
-        mock_fs.put.assert_any_call(
-            f'{home_path}/myapp.pex',
-            f'{home_fs_path}/blah-1.388585.133.497-review.pex')
+        mock_fs.put.assert_any_call(f"{home_path}/myapp.pex", f"{home_fs_path}/blah-1.388585.133.497-review.pex")
         # Check metadata has been cleaned
-        mock_fs.rm.assert_called_once_with(f'{home_fs_path}/blah-1.388585.133.497-review.json')
+        mock_fs.rm.assert_called_once_with(f"{home_fs_path}/blah-1.388585.133.497-review.json")
         # check envname
-        assert 'myapp' == result[1]
+        assert "myapp" == result[1]
 
 
 @mock.patch(f"{MODULE_TO_TEST}._is_archive_up_to_date")
@@ -220,9 +201,12 @@ def test_upload_env_in_a_pex():
 @mock.patch(f"{MODULE_TO_TEST}.packaging.get_default_fs")
 @mock.patch(f"{MODULE_TO_TEST}.getpass.getuser")
 def test_upload_spec_hdfs(
-    mock_get_user, mock_get_default_fs,
-    mock_pack_spec_in_pex, mock_resolve_fs, mock_dump_archive_metadata,
-    mock_is_archive_up_to_date
+    mock_get_user,
+    mock_get_default_fs,
+    mock_pack_spec_in_pex,
+    mock_resolve_fs,
+    mock_dump_archive_metadata,
+    mock_is_archive_up_to_date,
 ):
     mock_is_archive_up_to_date.return_value = False
     mock_fs = mock.MagicMock()
@@ -242,9 +226,7 @@ def test_upload_spec_local_fs():
     with tempfile.TemporaryDirectory() as tempdir:
         result_path = cluster_pack.upload_spec(spec_file, f"{tempdir}/package.pex")
         assert os.path.exists(result_path)
-        _check_metadata(
-            f"{tempdir}/package.json",
-            ["5a5f33b106aad8584345f5a0044a4188ce78b3f4"])
+        _check_metadata(f"{tempdir}/package.json", ["5a5f33b106aad8584345f5a0044a4188ce78b3f4"])
 
 
 def test_upload_spec_unique_name():
@@ -256,9 +238,7 @@ def test_upload_spec_unique_name():
 
         assert os.path.exists(result_path)
         assert result_path == f"{tempdir}/cluster_pack_myproject.pex"
-        _check_metadata(
-            f"{tempdir}/cluster_pack_myproject.json",
-            ["b8721a3c125d3f7edfa27d7b13236e696f652a16"])
+        _check_metadata(f"{tempdir}/cluster_pack_myproject.json", ["b8721a3c125d3f7edfa27d7b13236e696f652a16"])
 
 
 @mock.patch(f"{MODULE_TO_TEST}.packaging.pack_spec_in_pex")
@@ -292,30 +272,21 @@ def test_upload_spec_local_fs_changed_reqs(mock_pack_spec_in_pex):
         with open(pex_file, "w") as f:
             pass
 
-        result_path = cluster_pack.upload_spec(
-            spec_file,
-            pex_file)
+        result_path = cluster_pack.upload_spec(spec_file, pex_file)
 
         with open(spec_file, "a") as f:
             f.write("skein\n")
 
-        result_path1 = cluster_pack.upload_spec(
-            spec_file,
-            pex_file)
+        result_path1 = cluster_pack.upload_spec(spec_file, pex_file)
         mock_pack_spec_in_pex.call_count == 2
         assert os.path.exists(result_path)
         assert os.path.exists(result_path1)
-        _check_metadata(
-            f"{tempdir}/package.json",
-            ["0fd17ced922a2387fa660fb0cb78e1c77fbe3349"])
+        _check_metadata(f"{tempdir}/package.json", ["0fd17ced922a2387fa660fb0cb78e1c77fbe3349"])
 
 
 def test__handle_packages_use_local_wheel():
     current_packages = {"horovod": "0.18.2"}
-    uploader._handle_packages(
-        current_packages,
-        additional_packages={"horovod-0.19.0-cp36-cp36m-linux_x86_64.whl": ""}
-    )
+    uploader._handle_packages(current_packages, additional_packages={"horovod-0.19.0-cp36-cp36m-linux_x86_64.whl": ""})
 
     assert len(current_packages) == 1
     assert next(iter(current_packages.keys())) == "horovod-0.19.0-cp36-cp36m-linux_x86_64.whl"
@@ -325,9 +296,7 @@ def test__handle_packages_use_local_wheel():
 def test__handle_packages_use_other_package():
     current_packages = {"tensorflow": "0.15.2"}
     uploader._handle_packages(
-        current_packages,
-        additional_packages={"tensorflow_gpu": "0.15.3"},
-        ignored_packages="tensorflow"
+        current_packages, additional_packages={"tensorflow_gpu": "0.15.3"}, ignored_packages="tensorflow"
     )
 
     print(current_packages)
@@ -336,11 +305,14 @@ def test__handle_packages_use_other_package():
     assert next(iter(current_packages.values())) == "0.15.3"
 
 
-@pytest.mark.parametrize("spec_file, expected", [
-    pytest.param("/a/b/myproject/requirements.txt", "cluster_pack_myproject.pex"),
-    pytest.param("myproject/requirements.txt", "cluster_pack_myproject.pex"),
-    pytest.param("requirements.txt", "cluster_pack.pex"),
-])
+@pytest.mark.parametrize(
+    "spec_file, expected",
+    [
+        pytest.param("/a/b/myproject/requirements.txt", "cluster_pack_myproject.pex"),
+        pytest.param("myproject/requirements.txt", "cluster_pack_myproject.pex"),
+        pytest.param("requirements.txt", "cluster_pack.pex"),
+    ],
+)
 def test__unique_filename(spec_file, expected):
     assert expected == uploader._unique_filename(spec_file, packaging.PEX_PACKER)
 
@@ -352,25 +324,34 @@ def test_format_pex_requirements():
             requirements,
             f"{tempdir}/out.pex",
             # make isolated pex from current pytest virtual env
-            pex_inherit_path="false")
+            pex_inherit_path="false",
+        )
         pex_info = PexInfo.from_pex(f"{tempdir}/out.pex")
         cleaned_requirements = uploader._format_pex_requirements(pex_info)
-        assert ['pip==21.3.1', 'pipdeptree==2.0.0', 'six==1.15.0'] == cleaned_requirements
+        assert ["pip==21.3.1", "pipdeptree==2.0.0", "six==1.15.0"] == cleaned_requirements
 
 
-@pytest.mark.parametrize("req, expected", [
-    (["pipdeptree==2.0.0", 'GitPython==3.1.14', "six==1.15.0", 'Cython==0.29.22'],
-     ['cython==0.29.22', 'gitpython==3.1.14', "pipdeptree==2.0.0", 'six==1.15.0']),
-    (["pipdeptree==2.0.0", "six==1.15.0", 'gitpython==3.1.14', 'cython==0.29.22'],
-     ['cython==0.29.22', 'gitpython==3.1.14', "pipdeptree==2.0.0", 'six==1.15.0']),
-])
+@pytest.mark.parametrize(
+    "req, expected",
+    [
+        (
+            ["pipdeptree==2.0.0", "GitPython==3.1.14", "six==1.15.0", "Cython==0.29.22"],
+            ["cython==0.29.22", "gitpython==3.1.14", "pipdeptree==2.0.0", "six==1.15.0"],
+        ),
+        (
+            ["pipdeptree==2.0.0", "six==1.15.0", "gitpython==3.1.14", "cython==0.29.22"],
+            ["cython==0.29.22", "gitpython==3.1.14", "pipdeptree==2.0.0", "six==1.15.0"],
+        ),
+    ],
+)
 def test_sort_requirement(req, expected):
     assert uploader._sort_requirements(req) == expected
 
 
 def test_normalize_requirement():
-    assert ["tf-yarn", "typing-extension", "to-to"] == \
-        uploader._normalize_requirements(["tf_yarn", "typing_extension", "to-to"])
+    assert ["tf-yarn", "typing-extension", "to-to"] == uploader._normalize_requirements(
+        ["tf_yarn", "typing_extension", "to-to"]
+    )
 
 
 def _check_metadata(metadata_file, expected_json):


### PR DESCRIPTION
Put operation is not atomic, leading to a race condition when writing a pex file.
Switching to a put to temporary folder and move operation.