### PR TITLE
Forward stderr from failing pex process in exception

### DIFF
--- a/cluster_pack/packaging.py
+++ b/cluster_pack/packaging.py
@@ -33,6 +33,7 @@ JsonDictType = Dict[str, Any]
 class PexTooLargeError(RuntimeError):
     pass
 
+
 class PexCreationError(RuntimeError):
     pass
 
@@ -191,8 +192,8 @@ def pack_in_pex(requirements: List[str],
 
         if not allow_large_pex and os.path.getsize(output + tmp_ext) > 2 * 1024 * 1024 * 1024:
             raise PexTooLargeError("The generate pex is larger than 2Gb and won't be executable"
-                                       " by python; Please set the 'allow_large_pex' "
-                                       "flag in upload_env")
+                                   " by python; Please set the 'allow_large_pex' "
+                                   "flag in upload_env")
 
         if allow_large_pex:
             shutil.make_archive(output, 'zip', output + tmp_ext)

--- a/cluster_pack/packaging.py
+++ b/cluster_pack/packaging.py
@@ -33,6 +33,9 @@ JsonDictType = Dict[str, Any]
 class PexTooLargeError(RuntimeError):
     pass
 
+class PexCreationError(RuntimeError):
+    pass
+
 
 class PythonEnvDescription(NamedTuple):
     path_to_archive: str
@@ -181,15 +184,15 @@ def pack_in_pex(requirements: List[str],
             call = subprocess.run(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
             call.check_returncode()
 
-            if not allow_large_pex and os.path.getsize(output + tmp_ext) > 2 * 1024 * 1024 * 1024:
-                raise PexTooLargeError("The generate pex is larger than 2Gb and won't be executable"
-                                       " by python; Please set the 'allow_large_pex' "
-                                       "flag in upload_env")
-
         except CalledProcessError as err:
             _logger.exception('Cannot create pex')
             _logger.exception(err.stderr.decode("ascii"))
-            raise
+            raise PexCreationError(err.stderr.decode("ascii"))
+
+        if not allow_large_pex and os.path.getsize(output + tmp_ext) > 2 * 1024 * 1024 * 1024:
+            raise PexTooLargeError("The generate pex is larger than 2Gb and won't be executable"
+                                       " by python; Please set the 'allow_large_pex' "
+                                       "flag in upload_env")
 
         if allow_large_pex:
             shutil.make_archive(output, 'zip', output + tmp_ext)

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -356,7 +356,7 @@ def test_format_pex_requirements():
             pex_inherit_path="false")
         pex_info = PexInfo.from_pex(f"{tempdir}/out.pex")
         cleaned_requirements = uploader._format_pex_requirements(pex_info)
-        pip_version = 'pip==21.3.1' if sys.version_info.minor == 6 else 'pip==23.3'
+        pip_version = 'pip==21.3.1' if sys.version_info.minor == 6 else 'pip==23.3.1'
         assert [pip_version, 'pipdeptree==2.0.0', 'six==1.15.0'] == cleaned_requirements
 
 


### PR DESCRIPTION
This will allow to easily know the reason of pew build error when the user only gets the python exception without an easy access to error logs (e.g. in a notebook)