### PR TITLE
Improve robustness of _get_editable_requirements

### DIFF
--- a/cluster_pack/packaging.py
+++ b/cluster_pack/packaging.py
@@ -349,7 +349,8 @@ def _get_editable_requirements(executable: str = sys.executable) -> List[str]:
             if "." in _pkg:
                 continue
             imported = __import__(_pkg)
-            top_level_pkgs.append(os.path.dirname(imported.__file__))
+            if imported.__file__:
+                top_level_pkgs.append(os.path.dirname(imported.__file__))
     return top_level_pkgs
 
 


### PR DESCRIPTION
- it can happen that the found package name via __init__.py is not installed in the current environment
- for example if you have this structure

cluster-pack
├── cluster_pack
│   ├── __init__.py
│   ├── main.py
├── tests
│   ├── __init__.py
│   ├── test_main.py

tests will be found by setuptools.find_packages but cannot be imported