### PR TITLE
Relax constraint on Pex version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cloudpickle
-pex==2.1.137
+pex>=2.1.137
 conda-pack
 pip>=22.0
 pyarrow


### PR DESCRIPTION
Later versions of pex (at least 2.41.1) are able to run executables > 2GB, meaning there is no need for large_pex (zipped) code path any more.

We just relax and don't bump directly, to not break existing projects that have pinned their pex version, this will be done eventually